### PR TITLE
Resolve EDIROM commit SHA in separate build stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -18,7 +18,44 @@ ARG BUILD_DATE=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
 # build arguments for stadlerpeter/existdb
 ARG EXIST_DEFAULT_APP_PATH
 
-# STAGE 1a
+# STAGE 1a: Resolve Edirom commit SHA only (no XAR download)
+FROM bwbohl/sencha-cmd:2.1.0 AS commit-resolver
+
+# setup build arguments
+ARG EDIROM_VERSION_STRATEGY
+ARG EDIROM_OWNER
+ARG EDIROM_REF
+
+ARG BUILD_DATE
+
+# setup environment variables
+ENV EDIROM_VERSION_STRATEGY=${EDIROM_VERSION_STRATEGY:-1.0.0}
+ENV EDIROM_OWNER=${EDIROM_OWNER:-"Edirom"}
+ENV EDIROM_REF=${EDIROM_REF:-"v$EDIROM_VERSION_STRATEGY"}
+
+# Add Sencha Cmd to PATH
+ENV PATH="/opt/Sencha/Cmd:${PATH}"
+
+# copy gh-asset-downloader and entrypoint to commit-resolver
+COPY gitmodules/gh-asset-downloader /opt/gh-asset-downloader
+COPY xar-fetcher-entrypoint.sh /opt/xar-fetcher-entrypoint.sh
+
+# add requirements to baseimage
+RUN apt-get update && apt-get install -y --no-install-recommends \
+ --no-install-suggests \
+ bash curl libxml2-utils git
+
+## switch workdir
+WORKDIR /opt
+
+## resolve commit SHA only — no XAR download, no build
+RUN --mount=type=secret,id=GITHUB_API_TOKEN \
+    export GITHUB_API_TOKEN=$(cat /run/secrets/GITHUB_API_TOKEN) && \
+    echo "Token length: ${#GITHUB_API_TOKEN}" && \
+    /bin/bash /opt/xar-fetcher-entrypoint.sh --commit-only \
+      "$EDIROM_OWNER" Edirom-Online "$EDIROM_VERSION_STRATEGY" "$EDIROM_REF"
+
+# STAGE 1b
 FROM bwbohl/sencha-cmd:2.1.0 AS xar-fetcher
 
 # setup build arguments
@@ -69,7 +106,7 @@ RUN --mount=type=secret,id=GITHUB_API_TOKEN \
     # The xar-fetcher-entrypoint.sh writes EDIROM_COMMIT to /tmp/build_env.
     # This file will be copied to the next stage.
 
-# STAGE 1b: Build edirom config-deployer
+# STAGE 1c: Build edirom config-deployer
 
 FROM bwbohl/sencha-cmd:2.1.0 AS config-deployer-builder
 

--- a/build.sh
+++ b/build.sh
@@ -22,7 +22,7 @@ echo ""
 # This is to ensure we don't tag the intermediate stage with the final image name
 # as it is not needed and can cause issues with the build process.
 # Remove -t and its value from DOCKER_BUILD_ARGS
-XAR_FETCHER_ARGS=()
+COMMIT_RESOLVER_ARGS=()
 skip_next=0
 for arg in "${DOCKER_BUILD_ARGS[@]}"; do
     if [[ $skip_next -eq 1 ]]; then
@@ -31,14 +31,14 @@ for arg in "${DOCKER_BUILD_ARGS[@]}"; do
     fi
     #if --build-arg EDIROM_VERSION_STRATEGY=2.0.0 then add another --build-arg EXIST_DEFAULT_APP_PATH=xmldb:exist:///db/apps/Edirom-Online-Frontend
     if [[ "$arg" == EDIROM_VERSION_STRATEGY=* ]]; then
-        XAR_FETCHER_ARGS+=("$arg")
+        COMMIT_RESOLVER_ARGS+=("$arg")
         # Extract the version strategy
         version_strategy=$(echo "$arg" | cut -d'=' -f2)
         # Add the EXIST_DEFAULT_APP_PATH argument based on the version strategy
         if [[ "$version_strategy" == "2.0.0" ]]; then
-            XAR_FETCHER_ARGS+=("--build-arg" "EXIST_DEFAULT_APP_PATH=xmldb:exist:///db/apps/Edirom-Online-Frontend")
+            COMMIT_RESOLVER_ARGS+=("--build-arg" "EXIST_DEFAULT_APP_PATH=xmldb:exist:///db/apps/Edirom-Online-Frontend")
         else
-            XAR_FETCHER_ARGS+=("--build-arg" "EXIST_DEFAULT_APP_PATH=xmldb:exist:///db/apps/Edirom-Online")
+            COMMIT_RESOLVER_ARGS+=("--build-arg" "EXIST_DEFAULT_APP_PATH=xmldb:exist:///db/apps/Edirom-Online")
         fi
         skip_next=0
         continue
@@ -58,34 +58,22 @@ for arg in "${DOCKER_BUILD_ARGS[@]}"; do
         continue
     fi
     # Add the current argument to the list
-    XAR_FETCHER_ARGS+=("$arg")
+    COMMIT_RESOLVER_ARGS+=("$arg")
 done
 
-# 1. Build xar-fetcher stage and extract the commit SHA
-echo "Building xar-fetcher stage to fetch EDIROM commit..."
-echo "Using these build arguments: ${XAR_FETCHER_ARGS[*]}"
-# Ensure the xar-fetcher stage is built first to get the EDIROM commit
-# This stage will create a file /tmp/build_env with the EDIROM_COMMIT
-docker buildx build --target xar-fetcher --load -t temp-xar-fetcher "${XAR_FETCHER_ARGS[@]}" . \
-    && echo "xar-fetcher stage built successfully." \
-    || { echo "Error building xar-fetcher stage."; exit 1; }
+# 1. Build commit-resolver stage and export /tmp/build_env directly to the host filesystem
+echo "Building commit-resolver stage to resolve EDIROM commit SHA..."
+echo "Using these build arguments: ${COMMIT_RESOLVER_ARGS[*]}"
+docker buildx build --target commit-resolver --output type=local,dest=./build-output "${COMMIT_RESOLVER_ARGS[@]}" . \
+    && echo "commit-resolver stage completed successfully." \
+    || { echo "Error building commit-resolver stage."; exit 1; }
 
-# Create a temporary container to extract the build_env file
-# This file contains the EDIROM_COMMIT value
-# We will copy it to the host and then remove the temporary container
 echo ""
-echo "Extracting EDIROM_COMMIT from build_env file for use in final stage..."
-docker rm -f temp-xar-fetcher-container 2>/dev/null || true
-docker create --name temp-xar-fetcher-container temp-xar-fetcher
-docker cp temp-xar-fetcher-container:/tmp/build_env ./build_env
-docker rm temp-xar-fetcher-container
-docker image rm -f temp-xar-fetcher
-
-export EDIROM_COMMIT=$(cat ./build_env | cut -d'=' -f2)
+echo "Extracting EDIROM_COMMIT from build_env..."
+export EDIROM_COMMIT=$(cat ./build-output/tmp/build_env | cut -d'=' -f2)
 echo "Extracted EDIROM_COMMIT=$EDIROM_COMMIT"
 echo ""
-# Clean up the build_env file
-rm -f ./build_env
+rm -rf ./build-output
 
 # 2. Build the final image, passing the commit as a build-arg and any secrets/args
 echo "Preparing to build the final EDIROM Online Docker image..."

--- a/xar-fetcher-entrypoint.sh
+++ b/xar-fetcher-entrypoint.sh
@@ -10,6 +10,15 @@ echo
 
 # Validate settings.
 
+# Check for --commit-only flag
+COMMIT_ONLY=0
+if [[ "${1:-}" == "--commit-only" ]]; then
+    COMMIT_ONLY=1
+    shift
+    echo "Running in --commit-only mode: resolving commit SHA without downloading XARs."
+    echo
+fi
+
 # check if $GITHUB_API_TOKEN is set
 # If it is not set, try to load it from ~/.secrets if it exists.
 if [ -z "${GITHUB_API_TOKEN:-}" ]; then
@@ -29,7 +38,7 @@ fi
 # Ensure GITHUB_API_TOKEN is defined.
 [ -z "${GITHUB_API_TOKEN:-}" ] && { echo "Error: GITHUB_API_TOKEN variable is not defined. Please set it." >&2; exit 1; }
 # Validate number of arguments.
-[ $# -ne 4 ] && { echo "Usage: $0 [owner] [main_repo_name] [edirom_version_strategy] [target_ref]" >&2; exit 1; }
+[ $# -ne 4 ] && { echo "Usage: $0 [--commit-only] [owner] [main_repo_name] [edirom_version_strategy] [target_ref]" >&2; exit 1; }
 # Enable trace mode if TRACE variable is set to a non-empty string.
 # Using ${TRACE:-} to avoid "unbound variable" error when `set -u` is active.
 [ "${TRACE:-}" ] && set -x
@@ -62,6 +71,94 @@ elif [[ ! -x "$REF_CHECKER_SCRIPT" ]]; then
     echo "Error: gh-ref-type-checker script is not executable at $REF_CHECKER_SCRIPT" >&2
     exit 1
 fi
+
+# Resolve the commit SHA for a given owner/repo/ref without downloading or building anything.
+# Writes EDIROM_COMMIT=<sha> to /tmp/build_env.
+RESOLVE_COMMIT() {
+    local owner="$1"
+    local repo="$2"
+    local ref="$3"
+
+    local GH_API="https://api.github.com"
+    local GH_REPO="$GH_API/repos/$owner/$repo"
+    local FORMAT="Accept: application/vnd.github+json"
+    local AUTH="Authorization: Bearer $GITHUB_API_TOKEN"
+    local API_VERSION="X-GitHub-Api-Version: 2022-11-28"
+
+    echo "-> Resolving commit SHA for $owner/$repo @ $ref"
+    local ref_code=0
+    "$REF_CHECKER_SCRIPT" "$owner" "$repo" "$ref" || ref_code=$?
+    echo "gh-ref-type-checker returned code: $ref_code"
+
+    local release_or_branch=""
+    case $ref_code in
+        0) release_or_branch="release" ;;
+        1) release_or_branch="branch" ;;
+        2) echo "Error: Reference '$ref' not found in '$owner/$repo'." >&2; exit 1 ;;
+        3) echo "Error: API error while checking '$owner/$repo'." >&2; exit 1 ;;
+        *) echo "Error: Unknown exit code ($ref_code) from gh-ref-type-checker." >&2; exit 1 ;;
+    esac
+
+    if [[ "$release_or_branch" == "branch" ]]; then
+        echo "Resolving commit SHA from branch '$ref' via shallow clone..."
+        local temp_dir
+        temp_dir=$(mktemp -d -t commit_resolve_XXXXXX)
+        local repo_path="$temp_dir/$repo"
+        git clone --depth 1 -b "$ref" --single-branch \
+            "https://github.com/$owner/$repo.git" "$repo_path" \
+            || { echo "Error: Failed to clone $owner/$repo branch $ref." >&2; rm -rf "$temp_dir"; exit 1; }
+        local commit_hash
+        commit_hash=$(git -C "$repo_path" rev-parse HEAD)
+        echo "Commit hash: $commit_hash"
+        echo "EDIROM_COMMIT=$commit_hash" > /tmp/build_env
+        rm -rf "$temp_dir"
+
+    elif [[ "$release_or_branch" == "release" ]]; then
+        echo "Resolving commit SHA from release '$ref' via GitHub API..."
+        local release_api_url="$GH_REPO/releases/tags/$ref"
+        if [ "$ref" = "release-latest" ]; then
+            release_api_url="$GH_REPO/releases/latest"
+        fi
+        local release_response
+        release_response=$(curl -s -L -H "$FORMAT" -H "$AUTH" -H "$API_VERSION" "$release_api_url")
+
+        local tag_name
+        tag_name=$(echo "$release_response" | grep -oP '"tag_name": "\K[^"]+')
+        if [[ -z "$tag_name" ]]; then
+            echo "Warning: Could not extract tag_name from release response." >&2
+        fi
+
+        local tag_ref_url="$GH_API/repos/$owner/$repo/git/ref/tags/$tag_name"
+        local tag_ref_response
+        tag_ref_response=$(curl -s -L -H "$FORMAT" -H "$AUTH" -H "$API_VERSION" "$tag_ref_url")
+        local tag_object_url
+        tag_object_url=$(echo "$tag_ref_response" | grep -oP '"url": "\K[^"]+' | head -1)
+
+        local tag_object_response
+        tag_object_response=$(curl -s -L -H "$FORMAT" -H "$AUTH" -H "$API_VERSION" "$tag_object_url")
+        local tag_type
+        tag_type=$(echo "$tag_object_response" | grep -oP '"type": "\K[^"]+')
+        local commit_sha=""
+        if [[ "$tag_type" == "commit" ]]; then
+            commit_sha=$(echo "$tag_object_response" | grep -oP '"sha": "\K[^"]+' | head -1)
+        elif [[ "$tag_type" == "tag" ]]; then
+            local annotated_commit_url
+            annotated_commit_url=$(echo "$tag_object_response" | grep -oP '"object": {[^}]*"url": "\K[^"]+')
+            local annotated_commit_response
+            annotated_commit_response=$(curl -s -L -H "$FORMAT" -H "$AUTH" -H "$API_VERSION" "$annotated_commit_url")
+            commit_sha=$(echo "$annotated_commit_response" | grep -oP '"sha": "\K[^"]+')
+        fi
+
+        if [[ -n "$commit_sha" ]]; then
+            echo "Setting EDIROM_COMMIT to $commit_sha (from release tag $tag_name)."
+            echo "EDIROM_COMMIT=$commit_sha" > /tmp/build_env
+        else
+            echo "Warning: Could not extract commit SHA from release tag '$tag_name'." >&2
+        fi
+    fi
+
+    echo "Commit resolution completed for $owner/$repo at reference $ref."
+}
 
 # Define a function for fetching a release asset or checking out the github repository and build it.
 # This function will be used to fetch xar files from the Edirom-Online repository.
@@ -267,26 +364,38 @@ if [[ "$EDIROM_VERSION_STRATEGY" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ ]]; then
 
     if [[ "$EDIROM_VERSION_MAJOR" -ge 2 ]]; then
         echo "Edirom Edition version $EDIROM_VERSION_STRATEGY is >= 2.0.0."
-        echo "Fetching XAR files from Edirom-Online-Frontend and Edirom-Online-Backend repositories."
+        if [[ $COMMIT_ONLY -eq 1 ]]; then
+            echo "Resolving commit SHA from Edirom-Online-Backend repository."
+            RESOLVE_COMMIT "$EDIROM_OWNER" Edirom-Online-Backend "$EDIROM_REF" \
+                || { echo "Error: Failed to resolve Edirom-Online-Backend commit." >&2; exit 1; }
+        else
+            echo "Fetching XAR files from Edirom-Online-Frontend and Edirom-Online-Backend repositories."
 
-        # Fetch xar files from Edirom-Online-Backend repository.
-        GET_XAR "$EDIROM_OWNER" Edirom-Online-Backend "$EDIROM_REF" "*.xar" \
-            || { echo "Error: Failed to fetch Edirom-Online-Backend XAR files." >&2; exit 1; }
-        echo "Edirom-Online-Backend XAR file fetched successfully."
-        echo
+            # Fetch xar files from Edirom-Online-Backend repository.
+            GET_XAR "$EDIROM_OWNER" Edirom-Online-Backend "$EDIROM_REF" "*.xar" \
+                || { echo "Error: Failed to fetch Edirom-Online-Backend XAR files." >&2; exit 1; }
+            echo "Edirom-Online-Backend XAR file fetched successfully."
+            echo
 
-        # Fetch xar files from Edirom-Online-Frontend repository.
-        GET_XAR "$EDIROM_OWNER" Edirom-Online-Frontend "$EDIROM_REF" "*.xar" \
-            || { echo "Error: Failed to fetch Edirom-Online-Frontend XAR files." >&2; exit 1; }
-        echo "Edirom-Online-Frontend XAR file fetched successfully."
-        echo
+            # Fetch xar files from Edirom-Online-Frontend repository.
+            GET_XAR "$EDIROM_OWNER" Edirom-Online-Frontend "$EDIROM_REF" "*.xar" \
+                || { echo "Error: Failed to fetch Edirom-Online-Frontend XAR files." >&2; exit 1; }
+            echo "Edirom-Online-Frontend XAR file fetched successfully."
+            echo
+        fi
     else # EDIROM_VERSION_STRATEGY is a version number and less than 2.0.0.
         echo "Edirom Edition version $EDIROM_VERSION_STRATEGY is less than 2.0.0."
-        echo "Fetching XAR file from Edirom-Online repository."
-        GET_XAR "$EDIROM_OWNER" Edirom-Online "$EDIROM_REF" "*.xar" \
-            || { echo "Error: Failed to fetch Edirom-Online XAR files." >&2; exit 1; }
-        echo "Edirom-Online XAR file fetched successfully."
-        echo
+        if [[ $COMMIT_ONLY -eq 1 ]]; then
+            echo "Resolving commit SHA from Edirom-Online repository."
+            RESOLVE_COMMIT "$EDIROM_OWNER" Edirom-Online "$EDIROM_REF" \
+                || { echo "Error: Failed to resolve Edirom-Online commit." >&2; exit 1; }
+        else
+            echo "Fetching XAR file from Edirom-Online repository."
+            GET_XAR "$EDIROM_OWNER" Edirom-Online "$EDIROM_REF" "*.xar" \
+                || { echo "Error: Failed to fetch Edirom-Online XAR files." >&2; exit 1; }
+            echo "Edirom-Online XAR file fetched successfully."
+            echo
+        fi
     fi
 else
     echo "Error: EDIROM_VERSION_STRATEGY '$EDIROM_VERSION_STRATEGY' is not a valid version number (e.g., 1.0.0). Please provide a valid version number." >&2


### PR DESCRIPTION
Split commit resolution out of the XAR fetching stage so we can obtain
the EDIROM commit SHA without downloading XARs or performing builds. Add
a new commit-resolver stage in the Dockerfile (with gh-asset-downloader
and xar-fetcher entrypoint copied in), extend the entrypoint with a
--commit-only mode and a RESOLVE_COMMIT routine to determine commit SHAs
from releases or branches, and change build.sh to build the
commit-resolver stage with local output and read /tmp/build_env from the
extracted output. This allows extracting EDIROM_COMMIT more reliably and
avoids unnecessary work during commit resolution.