### PR TITLE
Clone repositories with submodules

### DIFF
--- a/xar-fetcher-entrypoint.sh
+++ b/xar-fetcher-entrypoint.sh
@@ -151,7 +151,7 @@ GET_XAR() {
 
         # Clone the repository and checkout the specified branch into a subdirectory
         local repo_path="$temp_dir/$repo"
-        git clone -b "$ref" --single-branch "https://github.com/$owner/$repo.git" "$repo_path" \
+        git clone -b "$ref" --single-branch --recurse-submodules "https://github.com/$owner/$repo.git" "$repo_path" \
             || { echo "Error: Failed to clone repository '$owner/$repo' branch '$ref'." >&2; exit 1; }
 
         # Change to the cloned repository directory


### PR DESCRIPTION
Ensure that when cloning repositories for builds the git clone includes
submodules. This change adds --recurse-submodules to the clone command
so docker images and build scripts that rely on submodule content will
have those submodules checked out, preventing missing files or build
failures.