### PR TITLE
feat: add roaster dependency download to Docker builds

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -101,6 +101,12 @@ RUN --mount=type=secret,id=GITHUB_API_TOKEN \
     && mkdir -p /tmp/add-xars \
     && cp Edirom-Online*.xar /tmp/add-xars/
 
+RUN echo "Downloading dependencies..." && \
+    mkdir -p /opt/roaster && \
+    cd /opt/roaster && \
+    curl -L -O "https://exist-db.org/exist/apps/public-repo/public/roaster-${ROASTER_VERSION}.xar" && \
+    cp roaster-*.xar /tmp/add-xars/;
+    
     #/bin/bash -c "echo \$GITHUB_API_TOKEN \$EDIROM_OWNER Edirom-Online \$EDIROM_VERSION_STRATEGY \$EDIROM_REF"
 
     # The xar-fetcher-entrypoint.sh writes EDIROM_COMMIT to /tmp/build_env.

--- a/Dockerfile.local
+++ b/Dockerfile.local
@@ -89,6 +89,11 @@ COPY config-deployer/ ./config-deployer/
 RUN cd config-deployer \
     && ant
 
+RUN echo "Downloading dependencies..." && \
+    mkdir -p /opt/roaster && \
+    cd /opt/roaster && \
+    curl -L -O "https://exist-db.org/exist/apps/public-repo/public/roaster-${ROASTER_VERSION}.xar";
+    
 # STAGE 2: Deploy to eXist-db
 FROM stadlerpeter/existdb:6.4.0 AS edirom-online
 
@@ -114,6 +119,7 @@ LABEL org.opencontainers.image.licenses="MIT"
 COPY --from=local-backend-builder /opt/eo-backend/build-xar/*.xar ${EXIST_HOME}/autodeploy/
 COPY --from=local-frontend-builder /opt/eo-frontend/build-xar/*.xar ${EXIST_HOME}/autodeploy/
 COPY --from=local-config-deployer-builder /opt/config-deployer/*.xar ${EXIST_HOME}/autodeploy/
+COPY --from=local-config-deployer-builder /opt/roaster/*.xar ${EXIST_HOME}/autodeploy/
 
 # Copy any additional XARs from add-xars/ (e.g. edition data packages)
 COPY add-xars/ /tmp/add-xars/


### PR DESCRIPTION
Add roaster XAR package download and deployment to both Dockerfile and Dockerfile.local. The roaster package is downloaded from the exist-db public repository during the build process and copied to the autodeploy directory for automatic installation in the eXist-db instance.